### PR TITLE
Print status of mapping only if `map` argument is set to `True`

### DIFF
--- a/R/2_buildSOM.R
+++ b/R/2_buildSOM.R
@@ -222,11 +222,10 @@ SOM <- function (data, xdim = 10, ydim = 10, rlen = 10, mst = 1,
     codes <- matrix(res$codes, nrow(codes), ncol(codes))
     colnames(codes) <- colnames(data)
     nhbrdist <- Dist.MST(codes)
-  }
-  
-  if(!silent) message("Mapping data to SOM\n")
+  } 
 
   if (map)
+    if(!silent) message("Mapping data to SOM\n")
     mapping <- MapDataToCodes(codes, data)
   else
     mapping <- NULL


### PR DESCRIPTION
**What is the purpose of this PR?**

The line `"Mapping data to SOM"` runs regardless of if the `map` parameter is set to `True` or not. Because our usage sets it to `False` all the time, it doesn't make sense to print this statement since we don't want to map the data to the subsetted dataset passed in. We should put this print statement under the control `if (map)` instead of before.

**How did you implement your changes**

See above.
